### PR TITLE
Support cancellation of RWhois crawling

### DIFF
--- a/RWhoisCrawler/RWhois/RWhoisConsumer.cs
+++ b/RWhoisCrawler/RWhois/RWhoisConsumer.cs
@@ -83,7 +83,10 @@ namespace Microsoft.Geolocation.RWhois.Crawler
 
         public virtual void Unsubscribe()
         {
-            this.unsubscriber.Dispose();
+            if (this.unsubscriber != null)
+            {
+                this.unsubscriber.Dispose();
+            }
         }
     }
 }

--- a/RWhoisCrawler/RWhois/RWhoisCrawler.cs
+++ b/RWhoisCrawler/RWhois/RWhoisCrawler.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Geolocation.RWhois.Crawler
             await this.client.ConnectAsync();
         }
 
-        public async Task CrawlRangesAsync(IEnumerable<IPAddressRange> parentRanges)
+        public async Task CrawlRangesAsync(IEnumerable<IPAddressRange> parentRanges, CancellationToken token)
         {
             if (parentRanges == null)
             {
@@ -97,6 +97,11 @@ namespace Microsoft.Geolocation.RWhois.Crawler
 
             foreach (var parentRange in parentRanges)
             {
+                if (token.IsCancellationRequested)
+                {
+                    token.ThrowIfCancellationRequested();
+                }
+
                 await this.CrawlRangeAsync(parentRange);
             }
         }


### PR DESCRIPTION
Currently, there seems to be no way to conveniently cancel RWhois crawling after a fixed period of time, say, one day.

I tried various methods from the calling code, i.e. by not modifying WhoisParsers, to kill the crawling thread but this still keep file handles open. Tried Join(timeout), ThreadAbort, ThreadInterrupt, but none of them had seemed to work.

Modified WhoisParsers to use CancellationTokenSource, in accordance with:
https://docs.microsoft.com/en-us/dotnet/standard/threading/cancellation-in-managed-threads?view=netframework-4.8
